### PR TITLE
fix: changing base image, now using azul/zulu-openjdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
-FROM java:7
+FROM azul/zulu-openjdk:7u222
+
+RUN apt-get update && \
+  apt-get install wget zip -y && \
+  apt-get clean
 
 RUN wget -P /opt https://s3-us-west-2.amazonaws.com/wso2-stratos/wso2am-1.9.1.zip && \
-    apt-get update && \
-    apt-get install -y zip && \
-    apt-get clean && \
     unzip /opt/wso2am-1.9.1.zip -d /opt && \
     rm /opt/wso2am-1.9.1.zip
+
+ENV JAVA_HOME /usr/lib/jvm/zulu-7-amd64
 
 EXPOSE 9443 9763 8243 8280 10397 7711
 
 ENTRYPOINT ["/opt/wso2am-1.9.1/bin/wso2server.sh"]
+


### PR DESCRIPTION
About this pull request, tried to use it today and some jessie dependencies are missing... don't know why.
So, after digging a little bit out there, I find out that wso2 can work with openjdk.
IMHO, try to use openjdk when possible is a good choice.

Thought that you would enjoy this...